### PR TITLE
15_動画教材のrakeタスク実装

### DIFF
--- a/db/csv_data/movie_data.csv
+++ b/db/csv_data/movie_data.csv
@@ -1,0 +1,32 @@
+title,url
+人生逆転サロンの活用法,https://www.youtube.com/embed/iFMNUM2Q9mg
+Slackの使い方,https://www.youtube.com/embed/x_KeaEUr3jo
+プログラミングを学習するための基礎知識,https://www.youtube.com/embed/Outcx4StSyU
+Webとは,https://www.youtube.com/embed/DDBiKpcvZp0
+Webを支える技術,https://www.youtube.com/embed/wvkK06fdR3Q
+Webサーバーについて,https://www.youtube.com/embed/O6tARRY81xM
+動的ページと静的ページ,https://www.youtube.com/embed/R4GYLo9S7vQ
+Gitの基本,https://www.youtube.com/embed/cdz-cs_kYto
+Gitを使ったクローン、プルリク、マージの流れについて解説,https://www.youtube.com/embed/JispFS6zeDw
+ソースコードをリモートリポジトリにプッシュするときの流れ,https://www.youtube.com/embed/FIfbOSy1Bzg
+Rubyで使用する主なクラスについて,https://www.youtube.com/embed/BVv2JNnkKfU
+putsについて,https://www.youtube.com/embed/TFrYp4J6KLY
+変数について,https://www.youtube.com/embed/U3yqlU7HGnk
+ifについて,https://www.youtube.com/embed/SOLT-5evKQQ
+配列について,https://www.youtube.com/embed/o43AAYhNfU4
+繰り返し処理について,https://www.youtube.com/embed/6XGB0MkcQ2w
+ハッシュについて,https://www.youtube.com/embed/YJ1SOXyCx78
+Ruby/Railsの環境構築1,https://www.youtube.com/embed/owzClWksQJc
+Ruby/Railsの環境構築2,https://www.youtube.com/embed/92F2sWL3Xko
+Hello World アプリの解説（実践的なコントローラの作り方）,https://www.youtube.com/embed/1jMlnGwHiXo
+resourcesを使わないCRUDアプリの解説,https://www.youtube.com/embed/b_NlIEAQkoo
+resourcesを使ったCRUDアプリの解説,https://www.youtube.com/embed/QWixLhP62M8
+デバッグツールの使い方,https://www.youtube.com/embed/dmkzIosRytI
+CSVデータインポートアプリの解説,https://www.youtube.com/embed/KqOoZQoJTG8
+Rakeタスクの実装,https://www.youtube.com/embed/EntRvD_KSNA
+Deviseを使ったログイン機能の実装,https://www.youtube.com/embed/AIUsm87NyaM
+Active Admin を使った管理者画面の作成,https://www.youtube.com/embed/3auqochKXfg
+Ransackを使った検索機能の実装,https://www.youtube.com/embed/dATIhg6S0Us
+RSpecを使ったテストコードの実装,https://www.youtube.com/embed/Zo9HKyQqwfs
+RailsへのMarkdownの導入,https://www.youtube.com/embed/fFS5_GfXvwE
+Chart.jsを使ったグラフの作成,https://www.youtube.com/embed/05Cl4zekcGk

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -16,4 +16,20 @@ namespace :import_csv do
   end
 
 
+# rake import_csv:movies
+  desc "movie_dataを読むこむ"
+
+  task movies: :environment do
+    list = Import.csv_data(path: "db/csv_data/movie_data.csv")
+
+    puts "インポート処理を開始"
+    begin
+      Movie.create!(list)
+      puts "インポート完了"
+    rescue ActiveModel::UnknownAttributeError => invalid
+      puts "インポートに失敗しました #{invalid}"
+    end
+  end
+
+
 end


### PR DESCRIPTION
### 変更点
- db/csv_dataにmovie_data.csvを追加

- import_csv.rakeにmovie_data.csvのインポート用rakeタスク実装
`$ rake import_csv:movies`で実行できます。