### PR TITLE
AWSテキスト教材詳細ページ実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,6 @@ end
  gem 'devise-i18n'
 
  gem 'devise-bootstrap-views'
+
+ gem 'redcarpet', '~> 2.3.0'
+ gem 'coderay'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -211,6 +212,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -223,6 +225,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n
+  redcarpet (~> 2.3.0)
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,10 +34,6 @@ main {
   font-size: 30px;
 }
 
-.container p {
-  line-height: 1.9em;
-}
-
 .table-container {
   width: 100%;
   margin: 0 auto;
@@ -49,6 +45,10 @@ main {
 
 .aws_text_head {
   background-color: #5D99FF;
+}
+
+.content-show {
+  padding: 120px 0 80px 0;
 }
 
 @media screen and (max-width: 991px){

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -2,5 +2,10 @@ class AwsTextsController < ApplicationController
   def index
     @aws_texts = AwsText.all.order("id asc")
   end
+
+  def show
+    @aws_text = AwsText.find(params[:id])
+  end
+  
   
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,50 @@
 module ApplicationHelper
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+        language = language.split(':')[0] if language.present?
+
+        case language.to_s
+        when 'rb'
+            lang = :ruby
+        when 'yml'
+            lang = :yaml
+        when 'css'
+            lang = :css
+        when 'html'
+            lang = :html
+        when ''
+            lang = :md
+        else
+            lang = language
+        end
+
+        CodeRay.scan(code, lang).div
+    end
+  end
+
+  def markdown(text)
+      html_render = HTMLwithCoderay.new(
+        filter_html: true,
+        hard_wrap: true,
+        link_attributes: { rel: 'nofollow', target: "_blank" }
+      )
+      options = {
+          autolink: true,
+          space_after_headers: true,
+          no_intra_emphasis: true,
+          fenced_code_blocks: true,
+          tables: true,
+          hard_wrap: true,
+          xhtml: true,
+          lax_html_blocks: true,
+          strikethrough: true
+      }
+      markdown = Redcarpet::Markdown.new(html_render, options)
+      markdown.render(text)
+  end
 end
+
+

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -16,7 +16,7 @@
         <% @aws_texts.each.with_index(1) do |aws_text, i| %>
           <tr>
             <td><%= i %></td>
-            <td><%= link_to aws_text.title, "#" %></td>
+            <td><%= link_to aws_text.title, aws_text_path(aws_text.id) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,4 @@
+<div class="content-show">
+  <h2><%= markdown(@aws_text.title).html_safe %></h2>
+  <%= markdown(@aws_text.content).html_safe %>
+</div>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,4 +1,4 @@
 <div class="content-show">
-  <h2><%= markdown(@aws_text.title).html_safe %></h2>
+  <h2><%= @aws_text.title %></h2>
   <%= markdown(@aws_text.content).html_safe %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'movies#index'
 
-  resources :aws_texts, only: [:index]
+  resources :aws_texts, only: [:index, :show]
 
 end


### PR DESCRIPTION
* 一覧ページの「内容」から詳細ページに移動

* 詳細ページの作成

* Markdownに対応した表示にしています