### PR TITLE
19_Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,7 +29,7 @@
 }
 
 .table-container {
-  width: 100%;
+  width: 710px;
   margin: 0 auto;
 }
 
@@ -80,8 +80,11 @@
   }
 
   .container p {
-    padding: 20px 0 10px 0;
+    width: 710px;
+    margin: 0 auto;
+    padding-bottom: 15px;
     font-size: 17px;
+    line-height: 1.9em;
   }
 
   .table {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,12 +8,6 @@
 @import "bootstrap/scss/bootstrap";
 
 
-main {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1rem;
-}
-
 .container-login {
   @extend .container-fluid;
   max-width: 576px;
@@ -82,6 +76,7 @@ main {
   
   .container {
     padding: 120px 0 80px 0;
+    margin: 0 auto;
   }
 
   .container p {
@@ -99,10 +94,11 @@ main {
 }
 
 @media screen and (min-width: 1200px){
-  main {
+  .container {
       width: 1200px;
   }
 }
+
 .alert-notice {
   @extend .alert-success;
   width: 100%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,7 +9,7 @@
 
 
 main {
-  max-width: 700px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 1rem;
 }
@@ -92,10 +92,17 @@ main {
   .table {
     width: 100%;
   }
+
+  .movie-body {
+    height: 200px;
+  }
 }
 
-
-
+@media screen and (min-width: 1200px){
+  main {
+      width: 1200px;
+  }
+}
 .alert-notice {
   @extend .alert-success;
   width: 100%;
@@ -104,4 +111,9 @@ main {
 .alert-alert {
   @extend .alert-danger;
   width: 100%;
+}
+
+// 動画教材
+.movie-title {
+  font-size: 1.7rem
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,6 +45,14 @@
   padding: 120px 0 80px 0;
 }
 
+@media screen and (min-width: 0px){
+  .container p.movie-title {
+    height: 200px;
+    font-size: 1.7rem;
+    line-height: 1.5em;
+  }
+}
+
 @media screen and (max-width: 991px){
   .container {
     font-size: 0.5rem;
@@ -80,11 +88,19 @@
   }
 
   .container p {
+    font-size: 17px;
+    line-height: 1.9em;
+  }
+
+  .contents p {
     width: 710px;
     margin: 0 auto;
     padding-bottom: 15px;
-    font-size: 17px;
-    line-height: 1.9em;
+  }
+
+  .content-show {
+    width: 710px;
+    margin: 0 auto;
   }
 
   .table {
@@ -110,9 +126,4 @@
 .alert-alert {
   @extend .alert-danger;
   width: 100%;
-}
-
-// 動画教材
-.movie-title {
-  font-size: 1.7rem
 }

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-  
+    @movies = Movie.all
   end
 end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -1,23 +1,24 @@
   <h2 class="text-center">AWS講座</h2>
-  <p>
-    注意！！！：AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。
-  </p>
-
-  <div class="table-container">
-    <table class="table table-striped">
-      <thead class="aws_text_head text-white">
-        <tr>
-          <th>No.</th>
-          <th>内容</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @aws_texts.each.with_index(1) do |aws_text, i| %>
+  <div class="contents">
+    <p>
+      注意！！！：AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。
+    </p>
+    <div class="table-container">
+      <table class="table table-striped">
+        <thead class="aws_text_head text-white">
           <tr>
-            <td><%= i %></td>
-            <td><%= link_to aws_text.title, aws_text_path(aws_text.id) %></td>
+            <th>No.</th>
+            <th>内容</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @aws_texts.each.with_index(1) do |aws_text, i| %>
+            <tr>
+              <td><%= i %></td>
+              <td><%= link_to aws_text.title, aws_text_path(aws_text.id) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -1,11 +1,10 @@
-<div class="container">
   <h2 class="text-center">AWS講座</h2>
   <p>
-    注意！！！AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。
+    注意！！！：AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。
   </p>
 
   <div class="table-container">
-    <table class="table table-striped ">
+    <table class="table table-striped">
       <thead class="aws_text_head text-white">
         <tr>
           <th>No.</th>
@@ -22,4 +21,3 @@
       </tbody>
     </table>
   </div>
-</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,6 @@
     <%= render 'shared/header'%>
     <%= render "layouts/notification" %>
     <main>
-      
       <%= yield %>
     </main>
     <footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,9 @@
     <%# ヘッダー %>
     <%= render 'shared/header'%>
     <%= render "layouts/notification" %>
-    <main>
+    <div class="container">
       <%= yield %>
-    </main>
+    </div>
     <footer>
     </footer>
   </body>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,2 +1,20 @@
-<h1>test<h1> <%# 表示テスト用 (indexページ作成時に消してください)%>
-<button type="button" class="btn btn-primary">Primary</button> <%# Bootstrapテスト用(indexページ作成時に消してください) %>
+<div class="container-fluid">
+  <div class="row">
+    <% @movies.each.with_index(1) do |movie, i| %>
+      <div class="col-12 col-md-6 col-lg-4">
+        <div class="card border-dark mb-3">
+          <div class="card-header p-0">
+            <div class="embed-responsive embed-responsive-16by9">
+              <iframe class="embed-responsive-item" src=<%= movie.url%> allowfullscreen></iframe>
+            </div>
+          </div>
+          <div class="card-body text-dark movie-body">
+            <p class="card-text movie-title">
+              Lv.<%= i %>：<%= movie.title %>
+            </p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
### 変更点
- moviesのindex.html.erbで、動画一覧を表示できるよう実装
現在のカード形式で表示できるように設定しました。

- movies_controller.rbで`@movies`を設定

- application.html.erbで`<main>`としていたものを`<div class="container">`に修正
AWSページのほうで、`container`を設定してされておりapplication.html.erb内の`<main>`が邪魔になったかつ、各ページ毎に`<div class="container">`を何度も書かなければならなくなるため、置き換えました。

- 上記変更に伴い、AWSページのレイアウトが崩れてしまったため、修正いたしました。
`<div class="container">`はapplication.html.erb内に記入したため、こちらからは削除いたしました。
application.scssで、`container p`を本家逆転教材のページを基に修正しました。